### PR TITLE
Stop using new(T); Start using &T{} #10

### DIFF
--- a/pkg/aws/dynamodb/service_test.go
+++ b/pkg/aws/dynamodb/service_test.go
@@ -33,8 +33,9 @@ func testDynamoDBDynamoPutItem(t *testing.T, cfg *configuration.Configuration) {
 	var input TestDynamoDBDynamoPutItemType
 	input.SomeParam = cfg.DynamoDB.PrimaryKey
 
-	dynamoNewSvc := &DynamoDB{}
-	dynamoNewSvc.DynamoDB = dynamoSvc
+	dynamoNewSvc := &DynamoDB{
+		DynamoDB: dynamoSvc,
+	}
 
 	err := dynamoNewSvc.DynamoPutItem(input, tableName)
 
@@ -55,8 +56,9 @@ func testDynamoDBDynamoGetItem(t *testing.T, cfg *configuration.Configuration) {
 	var input TestDynamoDBDynamoPutItemType
 	input.SomeParam = cfg.DynamoDB.PrimaryKey
 
-	dynamoNewSvc := &DynamoDB{}
-	dynamoNewSvc.DynamoDB = dynamoSvc
+	dynamoNewSvc := &DynamoDB{
+		DynamoDB: dynamoSvc,
+	}
 
 	err := dynamoNewSvc.DynamoPutItem(input, tableName)
 

--- a/pkg/aws/dynamodb/service_test.go
+++ b/pkg/aws/dynamodb/service_test.go
@@ -33,7 +33,7 @@ func testDynamoDBDynamoPutItem(t *testing.T, cfg *configuration.Configuration) {
 	var input TestDynamoDBDynamoPutItemType
 	input.SomeParam = cfg.DynamoDB.PrimaryKey
 
-	dynamoNewSvc := new(DynamoDB)
+	dynamoNewSvc := &DynamoDB{}
 	dynamoNewSvc.DynamoDB = dynamoSvc
 
 	err := dynamoNewSvc.DynamoPutItem(input, tableName)
@@ -55,7 +55,7 @@ func testDynamoDBDynamoGetItem(t *testing.T, cfg *configuration.Configuration) {
 	var input TestDynamoDBDynamoPutItemType
 	input.SomeParam = cfg.DynamoDB.PrimaryKey
 
-	dynamoNewSvc := new(DynamoDB)
+	dynamoNewSvc := &DynamoDB{}
 	dynamoNewSvc.DynamoDB = dynamoSvc
 
 	err := dynamoNewSvc.DynamoPutItem(input, tableName)

--- a/pkg/aws/dynamodb/session.go
+++ b/pkg/aws/dynamodb/session.go
@@ -25,8 +25,9 @@ func New(svc *pkgAws.Session, endpoint string) (*DynamoDB, error) {
 		return nil, newSvcErr
 	}
 
-	dynamoSvc := &DynamoDB{}
-	dynamoSvc.DynamoDB = dynamodb.New(newSvc)
+	dynamoSvc := &DynamoDB{
+		DynamoDB: dynamodb.New(newSvc),
+	}
 
 	return dynamoSvc, nil
 

--- a/pkg/aws/dynamodb/session.go
+++ b/pkg/aws/dynamodb/session.go
@@ -25,7 +25,7 @@ func New(svc *pkgAws.Session, endpoint string) (*DynamoDB, error) {
 		return nil, newSvcErr
 	}
 
-	dynamoSvc := new(DynamoDB)
+	dynamoSvc := &DynamoDB{}
 	dynamoSvc.DynamoDB = dynamodb.New(newSvc)
 
 	return dynamoSvc, nil

--- a/pkg/aws/dynamodb/util.go
+++ b/pkg/aws/dynamodb/util.go
@@ -27,7 +27,7 @@ func NewPutItemInput(input interface{}, table string) (*dynamodb.PutItemInput, e
 		return nil, dynamoInputErr
 	}
 
-	out := new(dynamodb.PutItemInput)
+	out := &dynamodb.PutItemInput{}
 	out = out.SetItem(dynamoInput)
 	out = out.SetTableName(table)
 
@@ -48,7 +48,7 @@ func NewGetItemInput(table, keyName, keyValue string) (*dynamodb.GetItemInput, e
 		return nil, intError.Format(ErrEmptyParameter, KeyValue)
 	}
 
-	out := new(dynamodb.GetItemInput)
+	out := &dynamodb.GetItemInput{}
 	out = out.SetTableName(table)
 	out = out.SetKey(
 		map[string]*dynamodb.AttributeValue{

--- a/pkg/aws/dynamodb/util_test.go
+++ b/pkg/aws/dynamodb/util_test.go
@@ -17,7 +17,7 @@ type TestUnmarshalStreamImageType struct {
 func TestNewPutItemInput(t *testing.T) {
 
 	tableName := "some_name"
-	in := new(TestUnmarshalStreamImageType)
+	in := &TestUnmarshalStreamImageType{}
 	in.SomeParam = "some_val"
 
 	out, err := NewPutItemInput(in, tableName)

--- a/pkg/aws/dynamodb/util_test.go
+++ b/pkg/aws/dynamodb/util_test.go
@@ -17,8 +17,9 @@ type TestUnmarshalStreamImageType struct {
 func TestNewPutItemInput(t *testing.T) {
 
 	tableName := "some_name"
-	in := &TestUnmarshalStreamImageType{}
-	in.SomeParam = "some_val"
+	in := &TestUnmarshalStreamImageType{
+		SomeParam: "some_val",
+	}
 
 	out, err := NewPutItemInput(in, tableName)
 

--- a/pkg/aws/rekognition/session.go
+++ b/pkg/aws/rekognition/session.go
@@ -25,8 +25,9 @@ func New(svc *pkgAws.Session, region string) (*Rekognition, error) {
 		return nil, newSvcErr
 	}
 
-	rekognitionSvc := &Rekognition{}
-	rekognitionSvc.Rekognition = rekognition.New(newSvc)
+	rekognitionSvc := &Rekognition{
+		Rekognition: rekognition.New(newSvc),
+	}
 
 	return rekognitionSvc, nil
 

--- a/pkg/aws/rekognition/session.go
+++ b/pkg/aws/rekognition/session.go
@@ -25,7 +25,7 @@ func New(svc *pkgAws.Session, region string) (*Rekognition, error) {
 		return nil, newSvcErr
 	}
 
-	rekognitionSvc := new(Rekognition)
+	rekognitionSvc := &Rekognition{}
 	rekognitionSvc.Rekognition = rekognition.New(newSvc)
 
 	return rekognitionSvc, nil

--- a/pkg/aws/rekognition/util.go
+++ b/pkg/aws/rekognition/util.go
@@ -268,9 +268,9 @@ func newInputImage(image []byte) (*rekognition.Image, error) {
 		return nil, intErr.Format(Image, ErrEmptyParameter)
 	}
 
-	out := &rekognition.Image{}
-
-	out.Bytes = image
+	out := &rekognition.Image{
+		Bytes: image,
+	}
 
 	return out, nil
 

--- a/pkg/aws/rekognition/util.go
+++ b/pkg/aws/rekognition/util.go
@@ -214,7 +214,7 @@ func NewCompareFacesInput(source, target []byte, similarity float64) (*rekogniti
 		return nil, newTargetInputImgErr
 	}
 
-	out := new(rekognition.CompareFacesInput)
+	out := &rekognition.CompareFacesInput{}
 	out = out.SetSimilarityThreshold(similarity)
 	out = out.SetSourceImage(newSourceInputImg)
 	out = out.SetTargetImage(newTargetInputImg)
@@ -235,7 +235,7 @@ func NewDetectFacesInput(source []byte) (*rekognition.DetectFacesInput, error) {
 		return nil, newInputImgErr
 	}
 
-	out := new(rekognition.DetectFacesInput)
+	out := &rekognition.DetectFacesInput{}
 	out = out.SetImage(newInputImg)
 
 	return out, nil
@@ -254,7 +254,7 @@ func NewDetectTextInput(source []byte) (*rekognition.DetectTextInput, error) {
 		return nil, newInputImgErr
 	}
 
-	out := new(rekognition.DetectTextInput)
+	out := &rekognition.DetectTextInput{}
 	out = out.SetImage(newInputImg)
 
 	return out, nil
@@ -268,7 +268,7 @@ func newInputImage(image []byte) (*rekognition.Image, error) {
 		return nil, intErr.Format(Image, ErrEmptyParameter)
 	}
 
-	out := new(rekognition.Image)
+	out := &rekognition.Image{}
 
 	out.Bytes = image
 

--- a/pkg/aws/s3/session.go
+++ b/pkg/aws/s3/session.go
@@ -25,8 +25,9 @@ func New(svc *pkgAws.Session, endpoint string) (*S3, error) {
 		return nil, newSvcErr
 	}
 
-	s3Svc := &S3{}
-	s3Svc.S3 = s3.New(newSvc)
+	s3Svc := &S3{
+		S3: s3.New(newSvc),
+	}
 
 	return s3Svc, nil
 

--- a/pkg/aws/s3/session.go
+++ b/pkg/aws/s3/session.go
@@ -25,7 +25,7 @@ func New(svc *pkgAws.Session, endpoint string) (*S3, error) {
 		return nil, newSvcErr
 	}
 
-	s3Svc := new(S3)
+	s3Svc := &S3{}
 	s3Svc.S3 = s3.New(newSvc)
 
 	return s3Svc, nil

--- a/pkg/aws/s3/util.go
+++ b/pkg/aws/s3/util.go
@@ -91,7 +91,7 @@ func ReadImage(path string) (*ReadImageOutput, error) {
 	file.Read(buffer)
 	contentType := http.DetectContentType(buffer)
 
-	out := new(ReadImageOutput)
+	out := &ReadImageOutput{}
 	out = out.SetBody(buffer)
 	out = out.SetContentType(contentType)
 	out = out.SetContentSize(contentSize)
@@ -107,7 +107,7 @@ func NewCreateBucketInput(bucketName string) (*s3.CreateBucketInput, error) {
 		return nil, intErr.Format(BucketName, ErrEmptyParameter)
 	}
 
-	out := new(s3.CreateBucketInput)
+	out := &s3.CreateBucketInput{}
 	out = out.SetBucket(bucketName)
 
 	return out, nil
@@ -124,7 +124,7 @@ func NewGetObjectInput(bucketName, source string) (*s3.GetObjectInput, error) {
 		return nil, intErr.Format(Source, ErrEmptyParameter)
 	}
 
-	out := new(s3.GetObjectInput)
+	out := &s3.GetObjectInput{}
 	out = out.SetBucket(bucketName)
 	out = out.SetKey(source)
 
@@ -148,7 +148,7 @@ func NewPutObjectInput(bucketName, fileName, contentType string, image []byte, s
 		return nil, intErr.Format(Image, ErrEmptyParameter)
 	}
 
-	out := new(s3.PutObjectInput)
+	out := &s3.PutObjectInput{}
 	out = out.SetBucket(bucketName)
 	out = out.SetKey(fileName)
 	out = out.SetContentType(contentType)
@@ -162,7 +162,7 @@ func NewPutObjectInput(bucketName, fileName, contentType string, image []byte, s
 // UnmarshalIOReadCloser extracts []byte from input.Body
 func UnmarshalIOReadCloser(input io.ReadCloser) ([]byte, error) {
 
-	buf := new(bytes.Buffer)
+	buf := &bytes.Buffer{}
 	_, err := buf.ReadFrom(input)
 	if err != nil {
 		return nil, err

--- a/pkg/aws/s3/util_test.go
+++ b/pkg/aws/s3/util_test.go
@@ -16,7 +16,7 @@ func TestReadImageOutput_SetBody(t *testing.T) {
 
 	body := []byte("some_body")
 
-	readImageOutput := new(ReadImageOutput)
+	readImageOutput := &ReadImageOutput{}
 	readImageOutput = readImageOutput.SetBody(body)
 
 	assert.Equal(t, body, readImageOutput.Body)
@@ -27,7 +27,7 @@ func TestReadImageOutput_SetContentType(t *testing.T) {
 
 	contentType := "some_content_type"
 
-	readImageOutput := new(ReadImageOutput)
+	readImageOutput := &ReadImageOutput{}
 	readImageOutput = readImageOutput.SetContentType(contentType)
 
 	assert.Equal(t, contentType, readImageOutput.ContentType)
@@ -38,7 +38,7 @@ func TestReadImageOutput_SetContentSize(t *testing.T) {
 
 	var contentSize int64 = 10
 
-	readImageOutput := new(ReadImageOutput)
+	readImageOutput := &ReadImageOutput{}
 	readImageOutput = readImageOutput.SetContentSize(contentSize)
 
 	assert.Equal(t, contentSize, readImageOutput.ContentSize)

--- a/pkg/aws/session.go
+++ b/pkg/aws/session.go
@@ -19,8 +19,9 @@ func New(input *SessionInput) (*Session, error) {
 		return nil, errors.New(ErrNoRegionProvided)
 	}
 
-	cfg := &aws.Config{}
-	cfg.Region = aws.String(input.region)
+	cfg := &aws.Config{
+		Region: aws.String(input.region),
+	}
 
 	awsSession, awsSessionErr := session.NewSession(cfg)
 	if awsSessionErr != nil {

--- a/pkg/aws/session.go
+++ b/pkg/aws/session.go
@@ -19,7 +19,7 @@ func New(input *SessionInput) (*Session, error) {
 		return nil, errors.New(ErrNoRegionProvided)
 	}
 
-	cfg := new(aws.Config)
+	cfg := &aws.Config{}
 	cfg.Region = aws.String(input.region)
 
 	awsSession, awsSessionErr := session.NewSession(cfg)
@@ -27,7 +27,7 @@ func New(input *SessionInput) (*Session, error) {
 		return nil, awsSessionErr
 	}
 
-	svc := new(Session)
+	svc := &Session{}
 
 	svc.Session = awsSession
 

--- a/pkg/aws/sns/session.go
+++ b/pkg/aws/sns/session.go
@@ -25,8 +25,9 @@ func New(svc *pkgAws.Session, endpoint string) (*SNS, error) {
 		return nil, newSvcErr
 	}
 
-	snsSvc := &SNS{}
-	snsSvc.SNS = sns.New(newSvc)
+	snsSvc := &SNS{
+		SNS: sns.New(newSvc),
+	}
 
 	return snsSvc, nil
 

--- a/pkg/aws/sns/session.go
+++ b/pkg/aws/sns/session.go
@@ -25,7 +25,7 @@ func New(svc *pkgAws.Session, endpoint string) (*SNS, error) {
 		return nil, newSvcErr
 	}
 
-	snsSvc := new(SNS)
+	snsSvc := &SNS{}
 	snsSvc.SNS = sns.New(newSvc)
 
 	return snsSvc, nil

--- a/pkg/aws/sns/util.go
+++ b/pkg/aws/sns/util.go
@@ -50,7 +50,7 @@ func NewPublishInput(input interface{}, endpoint string) (*sns.PublishInput, err
 		return nil, msgErr
 	}
 
-	out := new(sns.PublishInput)
+	out := &sns.PublishInput{}
 	out = out.SetMessage(string(msgBytes))
 	out = out.SetMessageStructure(MessageStructure)
 	out = out.SetTargetArn(endpoint)

--- a/pkg/aws/sqs/session.go
+++ b/pkg/aws/sqs/session.go
@@ -25,7 +25,7 @@ func New(svc *pkgAws.Session, endpoint string) (*SQS, error) {
 		return nil, newSvcErr
 	}
 
-	sqsSvc := new(SQS)
+	sqsSvc := &SQS{}
 	sqsSvc.SQS = sqs.New(newSvc)
 
 	return sqsSvc, nil

--- a/pkg/aws/sqs/session.go
+++ b/pkg/aws/sqs/session.go
@@ -25,8 +25,9 @@ func New(svc *pkgAws.Session, endpoint string) (*SQS, error) {
 		return nil, newSvcErr
 	}
 
-	sqsSvc := &SQS{}
-	sqsSvc.SQS = sqs.New(newSvc)
+	sqsSvc := &SQS{
+		SQS: sqs.New(newSvc),
+	}
 
 	return sqsSvc, nil
 

--- a/pkg/aws/sqs/util.go
+++ b/pkg/aws/sqs/util.go
@@ -18,7 +18,7 @@ func NewCreateQueueInput(queueName string) (*sqs.CreateQueueInput, error) {
 		return nil, intError.Format(QueueName, ErrEmptyParameter)
 	}
 
-	out := new(sqs.CreateQueueInput)
+	out := &sqs.CreateQueueInput{}
 	out = out.SetQueueName(queueName)
 
 	return out, nil
@@ -32,7 +32,7 @@ func NewGetQueueAttributesInput(queueUrl string) (*sqs.GetQueueAttributesInput, 
 		return nil, intError.Format(QueueUrl, ErrEmptyParameter)
 	}
 
-	out := new(sqs.GetQueueAttributesInput)
+	out := &sqs.GetQueueAttributesInput{}
 	out = out.SetQueueUrl(queueUrl)
 
 	return out, nil
@@ -51,7 +51,7 @@ func NewSendMessageInput(input interface{}, queueUrl string, base64Encode bool) 
 		return nil, intError.Format(QueueUrl, ErrEmptyParameter)
 	}
 
-	out := new(sqs.SendMessageInput)
+	out := &sqs.SendMessageInput{}
 
 	msgBody, err := marshalStructToJson(input)
 	if err != nil {
@@ -78,7 +78,7 @@ func NewGetQueueUrlInput(queueName string) (*sqs.GetQueueUrlInput, error) {
 		return nil, intError.Format(QueueName, ErrEmptyParameter)
 	}
 
-	out := new(sqs.GetQueueUrlInput)
+	out := &sqs.GetQueueUrlInput{}
 	out = out.SetQueueName(queueName)
 
 	return out, nil

--- a/pkg/aws/util.go
+++ b/pkg/aws/util.go
@@ -14,7 +14,7 @@ func NewSessionInput(region string) (*SessionInput, error) {
 		return nil, errors.New(ErrNoRegionProvided)
 	}
 
-	svc := new(SessionInput)
+	svc := &SessionInput{}
 
 	svc.region = region
 

--- a/pkg/aws/util.go
+++ b/pkg/aws/util.go
@@ -14,9 +14,9 @@ func NewSessionInput(region string) (*SessionInput, error) {
 		return nil, errors.New(ErrNoRegionProvided)
 	}
 
-	svc := &SessionInput{}
-
-	svc.region = region
+	svc := &SessionInput{
+		region: region,
+	}
 
 	return svc, nil
 


### PR DESCRIPTION
I just ran:
```
for x in `find . -name \*.go`; do sed -i '' -e 's/new(\([^)]*\))/\&\1{}/' $x; done
```

There was one that wasn't changed:
```
pkg/aws/dynamodb/service.go:
-       out := new(GetItemOutput)
+       out := &GetItemOutput{}
```

Results in the error . messge ` invalid pointer type *GetItemOutput for composite literal`.