### PR TITLE
Add devcontainer and Ona automations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+	"name": "aws-sdk-go-bindings",
+	"image": "mcr.microsoft.com/devcontainers/go:1.24-bookworm"
+}

--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -1,0 +1,14 @@
+tasks:
+  install-dependencies:
+    name: Install dependencies
+    command: |
+      go mod download
+    triggeredBy:
+      - postDevcontainerStart
+
+  test:
+    name: Run tests
+    command: |
+      go test -v -cover -race ./...
+    triggeredBy:
+      - manual


### PR DESCRIPTION
## Summary
- Add a Go devcontainer using the official devcontainers Go image
- Add Ona automations for dependency download on devcontainer start and manual test execution

## Validation
- Rebuilt devcontainer with `force=true`; rebuild completed and environment returned to running
- `jq empty .devcontainer/devcontainer.json`
- `gitpod automations validate .ona/automations.yaml`
- `go mod download`
- `go test -v -cover -race ./...`